### PR TITLE
Foundry - Fix CV Inputs not being labelled correctly

### DIFF
--- a/src/Foundry.cpp
+++ b/src/Foundry.cpp
@@ -241,7 +241,7 @@ struct Foundry : Module {
 		configInput(WRITE_INPUT, "Write");
 		configInput(RESET_INPUT, "Reset");
 		for (int i = 0; i < Sequencer::NUM_TRACKS; i++) {
-			configInput(CV_INPUTS, string::f("Track %c CV", i + 'A'));
+			configInput(CV_INPUTS + i, string::f("Track %c CV", i + 'A'));
 			configInput(CLOCK_INPUTS + i, string::f("Track %c clock", i + 'A'));
 		}
 		configInput(UNUSED1_INPUT, "Unused 1");


### PR DESCRIPTION
A/B/C/D CV inputs aren't labelled correctly:

![image](https://user-images.githubusercontent.com/7473960/178004735-f322c81f-8128-4b6e-8f75-9c3874dd7278.png)

 I haven't actually tested this fix, but it seems like it should work. 🙂