### PR TITLE
(WIP) PhraseSeq16/32: Add option to slide and change CV/note during tied steps

### DIFF
--- a/src/PhraseSeq16.cpp
+++ b/src/PhraseSeq16.cpp
@@ -454,11 +454,15 @@ struct PhraseSeq16 : Module {
 		json_t *keepCVTiedNotesJ = json_object_get(rootJ, "keepCVTiedNotes");
 		if (keepCVTiedNotesJ)
 			keepCVTiedNotes = json_is_true(keepCVTiedNotesJ);
+		else
+			keepCVTiedNotes = false;// legacy
 
 		// allowSlideTies
 		json_t *allowSlideTiesJ = json_object_get(rootJ, "allowSlideTies");
 		if (allowSlideTiesJ)
 			allowSlideTies = json_is_true(allowSlideTiesJ);
+		else
+			allowSlideTies = false;// legacy
 
 		// seqCVmethod
 		json_t *seqCVmethodJ = json_object_get(rootJ, "seqCVmethod");

--- a/src/PhraseSeq32.cpp
+++ b/src/PhraseSeq32.cpp
@@ -501,11 +501,15 @@ struct PhraseSeq32 : Module {
 		json_t *keepCVTiedNotesJ = json_object_get(rootJ, "keepCVTiedNotes");
 		if (keepCVTiedNotesJ)
 			keepCVTiedNotes = json_is_true(keepCVTiedNotesJ);
+		else
+			keepCVTiedNotes = false;// legacy
 
 		// allowSlideTies
 		json_t *allowSlideTiesJ = json_object_get(rootJ, "allowSlideTies");
 		if (allowSlideTiesJ)
 			allowSlideTies = json_is_true(allowSlideTiesJ);
+		else
+			allowSlideTies = false;// legacy
 
 		// seqCVmethod
 		json_t *seqCVmethodJ = json_object_get(rootJ, "seqCVmethod");


### PR DESCRIPTION
I propose to add a feature to change note and slide during tied steps.
The current behaviour doesn't allow that at all. Changing note of tied steps triggers the blinking warning.
Enabling a tie "propagate" the CV to succesive tied steps.

With a monophonic synth, this PR is the equivalent of holding a key down and pressing another key, the oscillator jumps or slides to the other note without retriggering the envelope. This is very common! Slide is generally called "Portamento" on such synthesizers. This PR also allows that.

The change is applied to both PhraseSeq 16 & 32.

This is marked as WIP until I have checked it doesn't have other implication. I took the liberty of setting both options as on by default and I also think that it could be only one option for both as they are related.

I made these small changes while working on a TB 303 clone module whose patterns very frequently have slides and ties.

Menu items:
![](https://pic.infini.fr/vqJRFrsc/4Bru8hG4.png)
Example:
![](https://pic.infini.fr/bE31R3ay/5cT1S3Xx.png)
The yellow trace is the gate and the red trace is CV, there are three tied steps and the third one has slide enabled.
